### PR TITLE
When a foreign key constraint has to be changed, the old one is dropp…

### DIFF
--- a/src/SQLGen/DiffToSQL/AlterTableChangeConstraintSQL.php
+++ b/src/SQLGen/DiffToSQL/AlterTableChangeConstraintSQL.php
@@ -13,14 +13,14 @@ class AlterTableChangeConstraintSQL implements SQLGenInterface {
         $table = $this->obj->table;
         $name = $this->obj->name;
         $schema = $this->obj->diff->getNewValue();
-        return "ALTER TABLE `$table` DROP CONSTRAINT `$key`;\nALTER TABLE `$table` ADD $schema;";
+        return "ALTER TABLE `$table` DROP CONSTRAINT `$name`;\nALTER TABLE `$table` ADD $schema;";
     }
 
     public function getDown() {
         $table = $this->obj->table;
         $name = $this->obj->name;
         $schema = $this->obj->diff->getOldValue();
-        return "ALTER TABLE `$table` DROP CONSTRAINT `$key`;\nALTER TABLE `$table` ADD $schema;";
+        return "ALTER TABLE `$table` DROP CONSTRAINT `$name`;\nALTER TABLE `$table` ADD $schema;";
     }
 
 }


### PR DESCRIPTION
…ed, but without a name

It will show up as `ALTER TABLE \`sometable\` DROP CONSTRAINT \`\``. This patch should fix the problem;